### PR TITLE
Bugfixes for network analysis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: Network
 Type: Package
 Title: Network Module for JASP
 Version: 0.0.0
-Date: 2020-04-08
+Date: 2020-05-01
 Author: JASP Team
 Website: jasp-stats.org
 Maintainer: JASP Team <info@jasp-stats.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: Network
 Type: Package
 Title: Network Module for JASP
 Version: 0.0.0
-Date: 2020-05-01
+Date: 2020-05-04
 Author: JASP Team
 Website: jasp-stats.org
 Maintainer: JASP Team <info@jasp-stats.org>

--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -459,7 +459,9 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   if (!is.null(plotContainer[["centralityPlot"]]) || !options[["plotCentrality"]])
     return()
 
-  plot <- createJaspPlot(title = gettext("Centrality Plot"), position = 52, dependencies = "plotCentrality", width = 480)
+  measuresToShow <- unlist(options[c("Betweenness", "Closeness", "Degree", "ExpectedInfluence")], use.names = FALSE)
+  plot <- createJaspPlot(title = gettext("Centrality Plot"), position = 52, width = 120 * sum(measuresToShow),
+                         dependencies = c("plotCentrality", "Betweenness", "Closeness", "Degree", "ExpectedInfluence"))
   plotContainer[["centralityPlot"]] <- plot
   if (is.null(network[["centrality"]]) || plotContainer$getError())
     return()
@@ -467,6 +469,12 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   wide <- network[["centrality"]]
 
   Long <- .networkAnalysisReshapeWideToLong(wide, network, "centrality")
+
+  if (!all(measuresToShow)) {
+    measuresToFilter <- c("Betweenness", "Closeness", "Degree", "Expected Influence")[measuresToShow]
+    Long <- subset(Long, measure %in% measuresToFilter)
+  }
+
   .networkAnalysisMakePlotFromLong(plot, Long, options)
 
 }

--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -560,7 +560,8 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   }
 
   # add a fill element to the mapping -- this is only used to add a legend for the names of the nodes.
-  if (!is.na(Long$nodeLabel))
+  hasNodeLabels <- !all(is.na(Long[["nodeLabel"]]))
+  if (hasNodeLabels)
     mapping$fill <- as.name("nodeLabel")
 
   g <- ggplot2::ggplot(Long, mapping) + guide
@@ -578,7 +579,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
   if (options[["showLegend"]] == "No legend")
     g <- g + ggplot2::theme(legend.position = "none")
-  else if (!is.na(Long$nodeLabel)) {
+  else if (hasNodeLabels) {
     # the fill aestethic introduces a set of points left of `1 = contNormal`.
     # the statement below sets the size of those points to 0, effectively making them invisible
     # keywidth removes the invisible space introduced so that the legends nicely line up (if there are multiple)

--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -691,8 +691,11 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
       for (i in seq_len(nGroups))
         groups[[i]] <- which(idx == i)
 
+      nonEmpty <- lengths(groups) > 0L
+      groups <- groups[nonEmpty]
+
       if (options[["manualColors"]])
-        nodeColor <- groupNames[idx, 2L]
+        nodeColor <- groupNames[nonEmpty, 2L]
     }
   }
 

--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -210,9 +210,9 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   if (!is.null(options[["colorNodesByData"]]) && length(options[["colorNodesByData"]]) != length(options[["variables"]])) {
     tb$addFootnote(
       gettextf("Only the first %d values of %s were used to color nodes (%d provided). ",
-              length(options[["variables"]]),
-              as.character(options[["colorNodesBy"]]),
-              length(options[["colorNodesByData"]]))
+               length(options[["variables"]]),
+               as.character(options[["colorNodesBy"]]),
+               length(options[["colorNodesByData"]]))
     )
   }
 
@@ -234,8 +234,8 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
         text <- gettext("Minimum edge strength ignored in the network plot because it was larger than the absolute value of the strongest edge.")
       } else {
         text <- gettextf("Minimum edge strength ignored in the network plot of group%1$s %2$s because it was larger than the absolute value of the strongest edge.",
-                        ifelse(sum(ignored) == 2L, "s", ""),
-                        paste0(names(network[["network"]])[ignored], collapse = ", ")
+                         ifelse(sum(ignored) == 2L, "s", ""),
+                         paste0(names(network[["network"]])[ignored], collapse = ", ")
         )
       }
       tb$addFootnote(text, symbol = gettext("<em>Warning: </em>"))
@@ -296,7 +296,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   for (i in seq_len(nGraphs)) {
 
     toAdd <- network[["centrality"]][[i]]
-    names(toAdd) <- c("Variable", paste0(c("Betweenness", "Closeness", "Strength"), i))
+    names(toAdd) <- c("Variable", paste0(c("Betweenness", "Closeness", "Strength", "Expected influence"), i))
     if (i == 1L) {# if more than 1 network drop the first column which indicates the variable
       TBcolumns <- toAdd
     } else {
@@ -460,10 +460,13 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     return()
 
   measuresToShow <- unlist(options[c("Betweenness", "Closeness", "Degree", "ExpectedInfluence")], use.names = FALSE)
-  plot <- createJaspPlot(title = gettext("Centrality Plot"), position = 52, width = 120 * sum(measuresToShow),
+  hasMeasures <- any(measuresToShow)
+
+  width <- if (hasMeasures) 120 * sum(measuresToShow) else 120
+  plot <- createJaspPlot(title = gettext("Centrality Plot"), position = 52, width = width,
                          dependencies = c("plotCentrality", "Betweenness", "Closeness", "Degree", "ExpectedInfluence"))
   plotContainer[["centralityPlot"]] <- plot
-  if (is.null(network[["centrality"]]) || plotContainer$getError())
+  if (is.null(network[["centrality"]]) || plotContainer$getError() || !hasMeasures)
     return()
 
   wide <- network[["centrality"]]
@@ -615,7 +618,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
       edge.width          = options[["edgeSize"]],
       node.width          = options[["nodeSize"]],
       maximum             = maxE,
-        minimum             = minE,
+      minimum             = minE,
       details             = options[["showDetails"]],
       labels              = labels,
       palette             = if (options[["manualColors"]]) NULL else options[["nodePalette"]],
@@ -763,7 +766,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   height <- setNames(rep(basePlotSize, nGraphs), names(allLegends))
   width  <- basePlotSize + allLegends * legendMultiplier
   for (v in names(allNetworks))
-      networkPlotContainer[[v]] <- createJaspPlot(title = v, width = width[v], height = height[v])
+    networkPlotContainer[[v]] <- createJaspPlot(title = v, width = width[v], height = height[v])
 
   JASP:::.suppressGrDevice({
 
@@ -1429,9 +1432,9 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
   if (checks[["errors"]][["fatal"]]) {
     message <- paste0(gettextf("Data supplied in %s cannot be used to determine variables types. Data should: ", options[["mgmVariableType"]]),
-                       gettext("<ul><li>start with the column name of the variable.</ul></li>"),
-                       gettext("<ul><li>contain an '=' to distinguish between column name and data type.</ul></li>"),
-                       gettext("<ul><li>end with either 'g' for Gaussian, 'c' for categorical, or 'p' for Poisson.</ul></li>")
+                      gettext("<ul><li>start with the column name of the variable.</ul></li>"),
+                      gettext("<ul><li>contain an '=' to distinguish between column name and data type.</ul></li>"),
+                      gettext("<ul><li>end with either 'g' for Gaussian, 'c' for categorical, or 'p' for Poisson.</ul></li>")
     )
     .quitAnalysis(message)
   }
@@ -1467,7 +1470,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     message <- gettextf("%1$s %2$s Data should only contain numeric:
                  -start with the column name of the variable.
                  -contain an '=' to distinguish between column name and coordinate.",
-                       defMsg, firstLine)
+                        defMsg, firstLine)
   } else if (length(checksX[["unmatched"]]) > 0 || length(checksY[["unmatched"]]) > 0) {
 
     unmatchedX <- paste(checksX[["unmatched"]], collapse = ", ")
@@ -1503,7 +1506,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   message <- NULL
   if (checks[["errors"]][["fatal"]]) {
     message <- gettextf("Data supplied in %s could not be used to determine variables types. Data should: \n- Start with the column name of the variable. \n- Contain an '=' to distinghuish betweem column name and group.",
-                       options[["colorNodesBy"]])
+                        options[["colorNodesBy"]])
     return(list(newData = NULL, message = message))
   }
 
@@ -1518,7 +1521,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
     newData <- rbind(newData, cbind(checks[["unmatched"]], undefGroup))
     message <- gettextf("Some entries of %1$s were not understood. These are now grouped under '%2$s'.",
-                       options[["colorNodesBy"]], undefGroup)
+                        options[["colorNodesBy"]], undefGroup)
   }
   newData <- newData[match(variables, newData[, 1]), ]
   return(list(newData = newData[, 2], message = message))

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -237,7 +237,7 @@ Form
 			name: "BootstrapType"
 			title: qsTr("Bootstrap Type")
 			Layout.rowSpan: 2
-			RadioButton { value: "nonparametric";	label: qsTr("Nonparametic"); checked: true	}
+			RadioButton { value: "nonparametric";	label: qsTr("Nonparametric"); checked: true	}
 			RadioButton { value: "case";			label: qsTr("Case")							}
 			RadioButton { value: "node";			label: qsTr("Node")							}
 			RadioButton { value: "parametric";		label: qsTr("Parametric")					}

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -52,9 +52,9 @@ Form
 	Group
 	{
 		title: qsTr("Plots")
-		CheckBox { name: "plotNetwork";		label: qsTr("Network plot")		}
-		CheckBox { name: "plotCentrality";	label: qsTr("Centrality plot")	}
-		CheckBox { name: "plotClustering";	label: qsTr("Clustering plot")	}
+		CheckBox { name: "plotNetwork";		label: qsTr("Network plot")								}
+		CheckBox { name: "plotCentrality";	label: qsTr("Centrality plot");		id: plotCentrality	}
+		CheckBox { name: "plotClustering";	label: qsTr("Clustering plot")							}
 	}
 
 	Group
@@ -437,6 +437,16 @@ Form
 			}
 			RadioButton { value: "circle";	label: qsTr("Circle")							}
 			RadioButton { value: "data";	label: qsTr("Data");	id: dataRatioButton		}
+		}
+
+		Group
+		{
+			title: qsTr("Measures shown in centrality plot")
+			enabled: plotCentrality.checked
+			CheckBox	{	name: "Betweenness";		label: qsTr("Betweenness");			checked: true	}
+			CheckBox	{	name: "Closeness";			label: qsTr("Closeness");			checked: true	}
+			CheckBox	{	name: "Degree";				label: qsTr("Betweenness");			checked: true	}
+			CheckBox	{	name: "ExpectedInfluence";	label: qsTr("Expected Influence");	checked: true	}
 		}
 
 		VariablesForm

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -381,7 +381,7 @@ Form
 		{
 			name: "showVariableNames";
 			title: qsTr("Show Variable Names")
-			RadioButton { value: "In nodes";		label: qsTr("In nodes");	 checked: true	}
+			RadioButton { value: "In nodes";			label: qsTr("In plot");	 checked: true	}
 			RadioButton { value: "In legend";		label: qsTr("In legend")					}
 		}
 

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -345,6 +345,13 @@ Form
 			DoubleField { name: "minEdgeStrength";	label: qsTr("Min edge strength");	defaultValue: 0; max: 10 }
 			DoubleField { name: "cut";				label: qsTr("Cut");					defaultValue: 0; max: 10 }
 			CheckBox	{ name: "showDetails";		label: qsTr("Show details") }
+			CheckBox
+			{
+								name: "edgeLabels";			label: qsTr("Edge labels");				checked: false
+				DoubleField {	name: "edgeLabelCex";		label: qsTr("Edge label size");			min: 0;			max: 10;	defaultValue: 1		}
+				DoubleField {	name: "edgeLabelPosition";	label: qsTr("Edge label position");		min: 0;			max: 1;		defaultValue: 0.5	}
+			}
+
 			DropDown
 			{
 				name: "edgeColors"


### PR DESCRIPTION
Fixes all issues mentioned in https://github.com/jasp-stats/jasp-issues/issues/702.

@JorisGoosen I'm unsure who to assign for this PR, so I chose you. I'll also make another PR to stable (so that Travis will complain about the plots). Any suggestions for reviewers?

The changes:

- When `Show variable names in legend` is ticked, the variable names are now shown in a legend for the centrality and clustering plot.
- Facets of the centrality plot can be toggled.
- Added a new centrality measure called `expected influence`.
- Values of edges can now be shown inside the network plot
- Fixed a bug in using manual colors for coloring nodes.

